### PR TITLE
Update translatable to version 5.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "marshmallow/sluggable": "^v1.9.0",
         "marshmallow/helpers": "^v2.19.0",
         "marshmallow/nova-tinymce": "^v2.2.1",
-        "marshmallow/translatable": "^v2.13.2",
+        "marshmallow/translatable": "^v5.0.0",
         "marshmallow/redirectable": "^v2.3.0",
         "marshmallow/seoable": "^v5.0.2",
         "marshmallow/nova-flexible": "^v5.2.0",


### PR DESCRIPTION
## Summary
- Updated marshmallow/translatable dependency from ^v2.13.2 to ^v5.0.0
- Ensures compatibility with Laravel Nova's built-in tabs (replacing eminiarts/tabs)
- Includes PHP 8.4 deprecation fixes and code quality improvements

## Changes
- Updated composer.json to require marshmallow/translatable ^v5.0.0

## Testing
- Existing translatable functionality should continue to work as expected
- No breaking changes identified in the API usage

Resolves #15